### PR TITLE
MDEV-7067: Server outputs Galera (WSREP) information, even if Galera …

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1902,7 +1902,10 @@ static void __cdecl kill_server(int sig_ptr)
 #endif
 
   /* Stop wsrep threads in case they are running. */
-  wsrep_stop_replication(NULL);
+  if (wsrep_running_threads > 0)
+  {
+    wsrep_stop_replication(NULL);
+  }
 
   close_connections();
 
@@ -5805,10 +5808,6 @@ int mysqld_main(int argc, char **argv)
 
       wsrep_create_appliers(wsrep_slave_threads - 1);
     }
-  }
-  else
-  {
-    wsrep_init_startup (false);
   }
 
  if (opt_bootstrap)

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -552,33 +552,34 @@ int wsrep_show_status (THD *thd, SHOW_VAR *var, char *buff,
     *v++= wsrep_status_vars[i];
 
   DBUG_ASSERT(i < maxi);
-  DBUG_ASSERT(wsrep != NULL);
 
-  wsrep_stats_var* stats= wsrep->stats_get(wsrep);
-  for (wsrep_stats_var *sv= stats; i < maxi && sv && sv->name; i++, sv++, v++)
-  {
-    v->name = thd->strdup(sv->name);
-    switch (sv->type) {
-    case WSREP_VAR_INT64:
-      v->value = (char*)thd->memdup(&sv->value._int64, sizeof(longlong));
-      v->type  = SHOW_LONGLONG;
-      break;
-    case WSREP_VAR_STRING:
-      v->value = thd->strdup(sv->value._string);
-      v->type  = SHOW_CHAR;
-      break;
-    case WSREP_VAR_DOUBLE:
-      v->value = (char*)thd->memdup(&sv->value._double, sizeof(double));
-      v->type  = SHOW_DOUBLE;
-      break;
+  if (wsrep != NULL) {
+    wsrep_stats_var* stats= wsrep->stats_get(wsrep);
+    for (wsrep_stats_var *sv= stats; i < maxi && sv && sv->name; i++, sv++, v++)
+    {
+      v->name = thd->strdup(sv->name);
+      switch (sv->type) {
+      case WSREP_VAR_INT64:
+        v->value = (char*)thd->memdup(&sv->value._int64, sizeof(longlong));
+        v->type  = SHOW_LONGLONG;
+        break;
+      case WSREP_VAR_STRING:
+        v->value = thd->strdup(sv->value._string);
+        v->type  = SHOW_CHAR;
+        break;
+      case WSREP_VAR_DOUBLE:
+        v->value = (char*)thd->memdup(&sv->value._double, sizeof(double));
+        v->type  = SHOW_DOUBLE;
+        break;
+      }
+      DBUG_ASSERT(i < maxi);
     }
-    DBUG_ASSERT(i < maxi);
+    wsrep->stats_free(wsrep, stats);
   }
-  wsrep->stats_free(wsrep, stats);
 
   my_qsort(buff, i, sizeof(*v), show_var_cmp);
 
-  v->name= 0; // terminator
+  v->name= 0;                                   // terminator
   return 0;
 }
 


### PR DESCRIPTION
…is disabled

Additional changes :
* On startup, do not initialize wsrep if wsrep_on=0.
* On shutdown, stop wsrep replication only if > 0 wsrep
threads are running.